### PR TITLE
feat: upgrade go-scheduler, implement db conn pooling config

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: go-notifications
 description: Helm chart for go-notifications
 type: application
 version: 1.0.1-alpha.1
-appVersion: "1.0.4"
+appVersion: "1.1.0"
 dependencies:
   - name: cockroachdb
     version: "9.1.1"


### PR DESCRIPTION
Automated changes triggered by [pull request](https://github.com/catalystsquad/go-notifications/pull/8)<br />upgrades the go-scheduler to include these changes: https://github.com/catalystsquad/go-scheduler/pull/12

implements configuration to be able to override the defaults of the go-scheduler.

upgrades to go 1.20.