### PR TITLE
chore: enable allowing merge commits

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -21,7 +21,7 @@ repository:
   allow_squash_merge: true
   # Either `true` to allow merging pull requests with a merge commit, or `false`
   # to prevent merging pull requests with merge commits.
-  allow_merge_commit: false
+  allow_merge_commit: true
   # Either `true` to allow rebase-merging pull requests, or `false` to prevent
   # rebase-merging.
   allow_rebase_merge: false


### PR DESCRIPTION
this setting being off prevents merging alpha to main