### PR TITLE
fix: add correlationId to notification events

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: go-notifications
 description: Helm chart for go-notifications
 type: application
 version: 1.1.0
-appVersion: "1.1.0"
+appVersion: "1.1.1"
 dependencies:
   - name: cockroachdb
     version: "9.1.1"


### PR DESCRIPTION
Automated changes triggered by [pull request](https://github.com/catalystsquad/go-notifications/pull/10)<br />adds correlationId with the value of the task definition ID to all notification events sent to notifo so that the correlationId can be used to find notifications to check their status.

updates the notifo http client, because it was missing correlationId fields previously.

also add a missing error check in the get scheduled notifications function.