### PR TITLE
feat: upgrade deps, go version

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: go-notifications
 description: Helm chart for go-notifications
 type: application
 version: 1.1.1
-appVersion: "1.1.1"
+appVersion: "1.2.0"
 dependencies:
   - name: cockroachdb
     version: "9.1.1"


### PR DESCRIPTION
Automated changes triggered by [pull request](https://github.com/catalystcommunity/go-notifications/pull/17)<br />the goal of this PR is simply to get the project compiling on main again. that ended up being an involved process because the dependencies had mismatches of their url and go mod path. that is now all addressed. the new release should create a new version in the catalystcommunity image repository, which should fix issues with the helm chart pointing to a missing image.

- upgrades all of the catalystcommunity dependencies so that the project will compile on main again, now that the dependencies have changed location.
- upgrade grpc dependencies as the protos had their plugins upgraded to get around 404 problems with the buf plugins.
- upgrade go, as the new buf plugin dependencies now require a higher go version.