### PR TITLE
fix: update chart.lock

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 9.1.1
 - name: notifo
   repository: https://raw.githubusercontent.com/catalystcommunity/charts/main/
-  version: 1.0.0-alpha.2
-digest: sha256:8b53a5b05ea6d658e3ed6ff582fc7eb0b3b1324ee9156eac21e9c34aefb8862b
-generated: "2022-11-28T14:29:47.971272737-07:00"
+  version: 1.0.0-alpha.3
+digest: sha256:a841bcbc57f23066f6672fc204c3f62ef4d8c7836fa901b80ff67c8151dc447b
+generated: "2025-01-08T16:43:02.264363773-07:00"


### PR DESCRIPTION
a `helm dep build chart` currently fails in this repo. this change fixes that.